### PR TITLE
No more Warning!!!

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@ csv2prolog: get2prolog.o stringlib.o
 	g++ -o csv2prolog get2prolog.o stringlib.o
 
 get2prolog.o: get2prolog.c
-	g++ -c get2prolog.c
+	g++ -x c get2prolog.c
 
 stringlib.o: 
 	gcc -c stringlib.c


### PR DESCRIPTION
get rid of that stupid clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated
